### PR TITLE
Pr/zigbee source matching

### DIFF
--- a/src/mac_features/ack_generator/nrf_802154_ack_data.c
+++ b/src/mac_features/ack_generator/nrf_802154_ack_data.c
@@ -357,11 +357,11 @@ bool addr_match_zigbee(const uint8_t * p_frame)
 {
     bool ret = false;
 
-    uint8_t                              frame_type;
-    uint8_t                              command_type;
-    nrf_802154_frame_parser_mhr_data_t   mhr_fields;
-    const uint8_t                      * p_cmd = p_frame; 
-    uint32_t                             location;
+    uint8_t                            frame_type;
+    uint8_t                            command_type;
+    nrf_802154_frame_parser_mhr_data_t mhr_fields;
+    const uint8_t                    * p_cmd = p_frame;
+    uint32_t                           location;
 
     // Check the frame type.
     frame_type = (p_frame[FRAME_TYPE_OFFSET] & FRAME_TYPE_MASK);
@@ -369,10 +369,11 @@ bool addr_match_zigbee(const uint8_t * p_frame)
     // Parse the MAC header and retrieve the command type.
     if (nrf_802154_frame_parser_mhr_parse(p_frame, &mhr_fields))
     {
-        // Note: Security header is not included in the offset. 
-        // If security is to be used at any point, additional calculation 
+        // Note: Security header is not included in the offset.
+        // If security is to be used at any point, additional calculation
         // here or in nrf_802154_frame_parser_mhr_parse needs to be implemented.
         p_cmd += mhr_fields.addressing_end_offset;
+
         command_type = *p_cmd;
     }
     else
@@ -381,7 +382,7 @@ bool addr_match_zigbee(const uint8_t * p_frame)
         // Command type cannot be checked, as addressing_end_offset value will be invalid.
         return true;
     }
-    
+
     // Check frame type and command type.
     if (frame_type == FRAME_TYPE_COMMAND && command_type == MAC_CMD_DATA_REQ)
     {
@@ -390,17 +391,21 @@ bool addr_match_zigbee(const uint8_t * p_frame)
         if (mhr_fields.src_addr_size == SRC_ADDR_TYPE_SHORT)
         {
             // Return true if address is not found on the m_pending_bits list.
-            ret = !addr_index_find(mhr_fields.p_src_addr, &location, NRF_802154_ACK_DATA_PENDING_BIT, false);
+            ret = !addr_index_find(mhr_fields.p_src_addr,
+                                   &location,
+                                   NRF_802154_ACK_DATA_PENDING_BIT,
+                                   false);
         }
     }
     return ret;
 }
+
 /**
  * @brief Standard-compliant implementation of address matching algorithm.
- * 
+ *
  * Function always returns true. It is IEEE 802.15.4 compliant, as per 6.7.3.
  * Higher layer should ensure empty data frame with no AR is sent afterwards.
- * 
+ *
  * TODO: Provide complete implementation (requires parsing security header).
  *
  * @param[in]  p_frame  Pointer to the frame for which the ACK frame is being prepared.
@@ -673,7 +678,7 @@ void nrf_802154_ack_data_src_matching_method(uint8_t match_method)
     {
         assert(!"Unrecognized source matching method passed.");
     }
-    
+
 }
 
 bool nrf_802154_ack_data_pending_bit_should_be_set(const uint8_t * p_frame)
@@ -685,12 +690,15 @@ bool nrf_802154_ack_data_pending_bit_should_be_set(const uint8_t * p_frame)
         case NRF_802154_SRC_MATCH_THREAD:
             ret = addr_match_thread(p_frame);
             break;
+
         case NRF_802154_SRC_MATCH_ZIGBEE:
             ret = addr_match_zigbee(p_frame);
             break;
+
         case NRF_802154_SRC_MATCH_STANDARD:
             ret = addr_match_standard_compliant(p_frame);
             break;
+
         default:
             // Assume Thread as default.
             ret = addr_match_thread(p_frame);

--- a/src/mac_features/ack_generator/nrf_802154_ack_data.c
+++ b/src/mac_features/ack_generator/nrf_802154_ack_data.c
@@ -43,7 +43,6 @@
 #include "mac_features/nrf_802154_frame_parser.h"
 #include "nrf_802154_config.h"
 #include "nrf_802154_const.h"
-#include "nrf_802154_types.h"
 
 /// Maximum number of Short Addresses of nodes for which there is ACK data to set.
 #define NUM_SHORT_ADDRESSES    NRF_802154_PENDING_SHORT_ADDRESSES
@@ -669,7 +668,7 @@ void nrf_802154_ack_data_reset(bool extended, uint8_t data_type)
     }
 }
 
-void nrf_802154_ack_data_src_matching_method(uint8_t match_method)
+void nrf_802154_ack_data_src_matching_method(nrf_802154_src_match_t match_method)
 {
     switch (match_method)
     {

--- a/src/mac_features/ack_generator/nrf_802154_ack_data.c
+++ b/src/mac_features/ack_generator/nrf_802154_ack_data.c
@@ -388,7 +388,7 @@ static bool addr_match_zigbee(const uint8_t * p_frame)
     if ((frame_type == FRAME_TYPE_COMMAND) && (*p_cmd == MAC_CMD_DATA_REQ))
     {
         // Check addressing type - in long case address, pb should always be 1.
-        if (mhr_fields.src_addr_size == SRC_ADDR_TYPE_SHORT)
+        if (mhr_fields.src_addr_size == SHORT_ADDRESS_SIZE)
         {
             // Return true if address is not found on the m_pending_bits list.
             ret = !addr_index_find(mhr_fields.p_src_addr,

--- a/src/mac_features/ack_generator/nrf_802154_ack_data.c
+++ b/src/mac_features/ack_generator/nrf_802154_ack_data.c
@@ -90,9 +90,9 @@ typedef struct
 } ie_arrays_t;
 
 // TODO: Combine below arrays to perform binary search only once per Ack generation.
-static pending_bit_arrays_t   m_pending_bit;
-static ie_arrays_t            m_ie;
-static nrf_802154_src_match_t m_src_matching_method;
+static pending_bit_arrays_t        m_pending_bit;
+static ie_arrays_t                 m_ie;
+static nrf_802154_src_addr_match_t m_src_matching_method;
 
 /***************************************************************************************************
  * @section Array handling helper functions
@@ -354,12 +354,11 @@ static bool addr_match_thread(const uint8_t * p_frame)
  */
 static bool addr_match_zigbee(const uint8_t * p_frame)
 {
-    bool ret = false;
-
     uint8_t                            frame_type;
     nrf_802154_frame_parser_mhr_data_t mhr_fields;
-    const uint8_t                    * p_cmd = p_frame;
     uint32_t                           location;
+    const uint8_t                    * p_cmd = p_frame;
+    bool                               ret   = false;
 
     // If ack data generator module is disabled do not perform check, return true by default.
     if (!m_pending_bit.enabled)
@@ -402,6 +401,7 @@ static bool addr_match_zigbee(const uint8_t * p_frame)
             ret = true;
         }
     }
+
     return ret;
 }
 
@@ -591,7 +591,7 @@ void nrf_802154_ack_data_init(void)
     memset(&m_ie, 0, sizeof(m_ie));
 
     m_pending_bit.enabled = true;
-    m_src_matching_method = NRF_802154_SRC_MATCH_THREAD;
+    m_src_matching_method = NRF_802154_SRC_ADDR_MATCH_THREAD;
 }
 
 void nrf_802154_ack_data_enable(bool enabled)
@@ -668,13 +668,13 @@ void nrf_802154_ack_data_reset(bool extended, uint8_t data_type)
     }
 }
 
-void nrf_802154_ack_data_src_matching_method(nrf_802154_src_match_t match_method)
+void nrf_802154_ack_data_src_addr_matching_method_set(nrf_802154_src_addr_match_t match_method)
 {
     switch (match_method)
     {
-        case NRF_802154_SRC_MATCH_THREAD:
-        case NRF_802154_SRC_MATCH_ZIGBEE:
-        case NRF_802154_SRC_MATCH_ALWAYS_1:
+        case NRF_802154_SRC_ADDR_MATCH_THREAD:
+        case NRF_802154_SRC_ADDR_MATCH_ZIGBEE:
+        case NRF_802154_SRC_ADDR_MATCH_ALWAYS_1:
             m_src_matching_method = match_method;
             break;
 
@@ -690,15 +690,15 @@ bool nrf_802154_ack_data_pending_bit_should_be_set(const uint8_t * p_frame)
 
     switch (m_src_matching_method)
     {
-        case NRF_802154_SRC_MATCH_THREAD:
+        case NRF_802154_SRC_ADDR_MATCH_THREAD:
             ret = addr_match_thread(p_frame);
             break;
 
-        case NRF_802154_SRC_MATCH_ZIGBEE:
+        case NRF_802154_SRC_ADDR_MATCH_ZIGBEE:
             ret = addr_match_zigbee(p_frame);
             break;
 
-        case NRF_802154_SRC_MATCH_ALWAYS_1:
+        case NRF_802154_SRC_ADDR_MATCH_ALWAYS_1:
             ret = addr_match_standard_compliant(p_frame);
             break;
 

--- a/src/mac_features/ack_generator/nrf_802154_ack_data.c
+++ b/src/mac_features/ack_generator/nrf_802154_ack_data.c
@@ -363,6 +363,12 @@ bool addr_match_zigbee(const uint8_t * p_frame)
     const uint8_t                    * p_cmd = p_frame;
     uint32_t                           location;
 
+    // If ack data generator module is disabled do not perform check, return true by default.
+    if (!m_pending_bit.enabled)
+    {
+        return true;
+    }
+
     // Check the frame type.
     frame_type = (p_frame[FRAME_TYPE_OFFSET] & FRAME_TYPE_MASK);
 

--- a/src/mac_features/ack_generator/nrf_802154_ack_data.h
+++ b/src/mac_features/ack_generator/nrf_802154_ack_data.h
@@ -104,14 +104,15 @@ void nrf_802154_ack_data_reset(bool extended, uint8_t data_type);
 /**
  * @brief Select the source matching algorithm.
  *
- * @note This method should only be called in the initialization phase.
+ * @note This method should be called after driver initialization, but before transceiver is enabled.
  *
- * When calling @ref nrf_802154_ack_data_pending_bit_should_be_set method, several different
- * algorithms can be chosen to determine whether the pending bit should be set.
+ * When calling @ref nrf_802154_ack_data_pending_bit_should_be_set method, it will choose one of
+ * several source address matching algorithms. In order for specific algorithm to be chosen, this
+ * function should be called beforehand.
  *
  * @param[in]  match_method Source matching method to be used.
  */
-void nrf_802154_ack_data_src_matching_method(nrf_802154_src_match_t match_method);
+void nrf_802154_ack_data_src_addr_matching_method_set(nrf_802154_src_addr_match_t match_method);
 
 /**
  * @brief Checks if a pending bit is to be set in the ACK frame sent in response to a given frame.

--- a/src/mac_features/ack_generator/nrf_802154_ack_data.h
+++ b/src/mac_features/ack_generator/nrf_802154_ack_data.h
@@ -99,16 +99,16 @@ bool nrf_802154_ack_data_for_addr_clear(const uint8_t * p_addr, bool extended, u
  */
 void nrf_802154_ack_data_reset(bool extended, uint8_t data_type);
 
-/** 
+/**
  * @brief Select the source matching algorithm.
- * 
+ *
  * @note This method should only be called in the initialization phase.
- * 
+ *
  * When calling nrf_802154_ack_data_pending_bit_should_be_set method, several different
  * algorithms can be chosen to determine whether the pending bit should be set.
- * 
+ *
  * @see nrf_802154_src_match_t
- * 
+ *
  * @param[in]  match_method Source matching method to be used.
  */
 void nrf_802154_ack_data_src_matching_method(uint8_t match_method);

--- a/src/mac_features/ack_generator/nrf_802154_ack_data.h
+++ b/src/mac_features/ack_generator/nrf_802154_ack_data.h
@@ -40,6 +40,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "nrf_802154_types.h"
+
 /**
  * @brief Initializes the ACK data generator module.
  */
@@ -107,11 +109,9 @@ void nrf_802154_ack_data_reset(bool extended, uint8_t data_type);
  * When calling @ref nrf_802154_ack_data_pending_bit_should_be_set method, several different
  * algorithms can be chosen to determine whether the pending bit should be set.
  *
- * @see nrf_802154_src_match_t
- *
  * @param[in]  match_method Source matching method to be used.
  */
-void nrf_802154_ack_data_src_matching_method(uint8_t match_method);
+void nrf_802154_ack_data_src_matching_method(nrf_802154_src_match_t match_method);
 
 /**
  * @brief Checks if a pending bit is to be set in the ACK frame sent in response to a given frame.

--- a/src/mac_features/ack_generator/nrf_802154_ack_data.h
+++ b/src/mac_features/ack_generator/nrf_802154_ack_data.h
@@ -99,6 +99,20 @@ bool nrf_802154_ack_data_for_addr_clear(const uint8_t * p_addr, bool extended, u
  */
 void nrf_802154_ack_data_reset(bool extended, uint8_t data_type);
 
+/** 
+ * @brief Select the source matching algorithm.
+ * 
+ * @note This method should only be called in the initialization phase.
+ * 
+ * When calling nrf_802154_ack_data_pending_bit_should_be_set_thread method, several different
+ * algorithms can be chosen to determine whether the pending bit should be set.
+ * 
+ * @see nrf_802154_src_match_t
+ * 
+ * @param[in]  match_method Source matching method to be used.
+ */
+void nrf_802154_ack_data_src_matching_method(uint8_t match_method);
+
 /**
  * @brief Checks if a pending bit is to be set in the ACK frame sent in response to a given frame.
  *

--- a/src/mac_features/ack_generator/nrf_802154_ack_data.h
+++ b/src/mac_features/ack_generator/nrf_802154_ack_data.h
@@ -104,7 +104,7 @@ void nrf_802154_ack_data_reset(bool extended, uint8_t data_type);
  * 
  * @note This method should only be called in the initialization phase.
  * 
- * When calling nrf_802154_ack_data_pending_bit_should_be_set_thread method, several different
+ * When calling nrf_802154_ack_data_pending_bit_should_be_set method, several different
  * algorithms can be chosen to determine whether the pending bit should be set.
  * 
  * @see nrf_802154_src_match_t

--- a/src/mac_features/ack_generator/nrf_802154_ack_data.h
+++ b/src/mac_features/ack_generator/nrf_802154_ack_data.h
@@ -104,7 +104,7 @@ void nrf_802154_ack_data_reset(bool extended, uint8_t data_type);
  *
  * @note This method should only be called in the initialization phase.
  *
- * When calling nrf_802154_ack_data_pending_bit_should_be_set method, several different
+ * When calling @ref nrf_802154_ack_data_pending_bit_should_be_set method, several different
  * algorithms can be chosen to determine whether the pending bit should be set.
  *
  * @see nrf_802154_src_match_t

--- a/src/nrf_802154.c
+++ b/src/nrf_802154.c
@@ -605,6 +605,11 @@ void nrf_802154_pan_coord_set(bool enabled)
     nrf_802154_pib_pan_coord_set(enabled);
 }
 
+void nrf_802154_src_matching_method(nrf_802154_src_match_t match_method)
+{
+    nrf_802154_ack_data_src_matching_method(match_method);
+}
+
 bool nrf_802154_ack_data_set(const uint8_t * p_addr,
                              bool            extended,
                              const void    * p_data,

--- a/src/nrf_802154.c
+++ b/src/nrf_802154.c
@@ -605,9 +605,9 @@ void nrf_802154_pan_coord_set(bool enabled)
     nrf_802154_pib_pan_coord_set(enabled);
 }
 
-void nrf_802154_src_matching_method(nrf_802154_src_match_t match_method)
+void nrf_802154_src_addr_matching_method_set(nrf_802154_src_addr_match_t match_method)
 {
-    nrf_802154_ack_data_src_matching_method(match_method);
+    nrf_802154_ack_data_src_addr_matching_method_set(match_method);
 }
 
 bool nrf_802154_ack_data_set(const uint8_t * p_addr,

--- a/src/nrf_802154.h
+++ b/src/nrf_802154.h
@@ -1001,6 +1001,20 @@ void nrf_802154_pan_coord_set(bool enabled);
  */
 bool nrf_802154_pan_coord_get(void);
 
+/** 
+ * @brief Select the source matching algorithm.
+ * 
+ * @note This method should only be called in the initialization phase.
+ * 
+ * When calling nrf_802154_ack_data_pending_bit_should_be_set_thread method, several different
+ * algorithms can be chosen to determine whether the pending bit should be set.
+ * 
+ * @see nrf_802154_src_match_t
+ * 
+ * @param[in]  match_method Source matching method to be used.
+ */
+void nrf_802154_src_matching_method(nrf_802154_src_match_t match_method);
+
 /**
  * @brief Adds the address of a peer node for which the provided ACK data is to be set to the pending bit list.
  * 

--- a/src/nrf_802154.h
+++ b/src/nrf_802154.h
@@ -1021,6 +1021,9 @@ void nrf_802154_src_matching_method(nrf_802154_src_match_t match_method);
  * Pending bit list works differently for Thread and Zigbee applications.
  * In case of Thread, pending_bit is set for addresses found on the list.
  * In case of Zigbee, pending_bit is set for short addresses not found on the list.
+ * In case of standard-compliant method, pending bit is always true, which requires
+ * empty data frame with AR set to 0 to be transmitted immediately afterwards.
+ * 
  * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
  *
  * @param[in]  p_addr    Array of bytes containing the address of the node (little-endian).
@@ -1046,6 +1049,9 @@ bool nrf_802154_ack_data_set(const uint8_t * p_addr,
  * Pending bit list works differently for Thread and Zigbee applications.
  * In case of Thread, pending_bit is set for addresses found on the list.
  * In case of Zigbee, pending_bit is set for short addresses not found on the list.
+ * In case of standard-compliant method, pending bit is always true, which requires
+ * empty data frame with AR set to 0 to be transmitted immediately afterwards.
+ * 
  * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
  *
  * @param[in]  p_addr    Array of bytes containing the address of the node (little-endian).
@@ -1084,6 +1090,9 @@ void nrf_802154_auto_pending_bit_set(bool enabled);
  * Pending bit list works differently for Thread and Zigbee applications.
  * In case of Thread, pending_bit is set for addresses found on the list.
  * In case of Zigbee, pending_bit is set for short addresses not found on the list.
+ * In case of standard-compliant method, pending bit is always true, which requires
+ * empty data frame with AR set to 0 to be transmitted immediately afterwards.
+ * 
  * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
  * 
  * @note This function makes a copy of the given address.
@@ -1102,6 +1111,9 @@ bool nrf_802154_pending_bit_for_addr_set(const uint8_t * p_addr, bool extended);
  * Pending bit list works differently for Thread and Zigbee applications.
  * In case of Thread, pending_bit is set for addresses found on the list.
  * In case of Zigbee, pending_bit is set for short addresses not found on the list.
+ * In case of standard-compliant method, pending bit is always true, which requires
+ * empty data frame with AR set to 0 to be transmitted immediately afterwards.
+ * 
  * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
  *
  * @param[in]  p_addr    Array of bytes containing the address of the node (little-endian).
@@ -1118,6 +1130,9 @@ bool nrf_802154_pending_bit_for_addr_clear(const uint8_t * p_addr, bool extended
  * Pending bit list works differently for Thread and Zigbee applications.
  * In case of Thread, pending_bit is set for addresses found on the list.
  * In case of Zigbee, pending_bit is set for short addresses not found on the list.
+ * In case of standard-compliant method, pending bit is always true, which requires
+ * empty data frame with AR set to 0 to be transmitted immediately afterwards.
+ * 
  * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
  *
  * @param[in]  extended  If the function is to remove all extended MAC addresses or all short

--- a/src/nrf_802154.h
+++ b/src/nrf_802154.h
@@ -1004,27 +1004,25 @@ bool nrf_802154_pan_coord_get(void);
 /**
  * @brief Select the source matching algorithm.
  *
- * @note This method should only be called in the initialization phase.
+ * @note This method should be called after driver initialization, but before transceiver is enabled.
  *
  * When calling nrf_802154_ack_data_pending_bit_should_be_set_thread method, several different
- * algorithms can be chosen to determine whether the pending bit should be set.
- *
- * @see nrf_802154_src_match_t
+ * algorithms can be chosen to determine whether the pending bit in ack should be set.
  *
  * @param[in]  match_method Source matching method to be used.
  */
 void nrf_802154_src_matching_method(nrf_802154_src_match_t match_method);
 
 /**
- * @brief Adds the address of a peer node for which the provided ACK data is to be set to the pending bit list.
+ * @brief Adds the address of a peer node for which the provided ACK data is to be added to the pending bit list.
  *
  * Pending bit list works differently for Thread and Zigbee applications.
- * In case of Thread, pending_bit is set for addresses found on the list.
- * In case of Zigbee, pending_bit is set for short addresses not found on the list.
+ * In case of Thread, pending_bit is set only for the addresses found in the list.
+ * In case of Zigbee, pending_bit is cleared only for the short addresses found in the list.
  * In case of standard-compliant method, pending bit is always true, which requires
  * empty data frame with AR set to 0 to be transmitted immediately afterwards.
  *
- * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
+ * Used method can be set during initialization phase by calling @ref nrf_802154_src_matching_method.
  *
  * @param[in]  p_addr    Array of bytes containing the address of the node (little-endian).
  * @param[in]  extended  If the given address is an extended MAC address or a short MAC address.
@@ -1047,12 +1045,12 @@ bool nrf_802154_ack_data_set(const uint8_t * p_addr,
  * The ACK data that was previously set for the given address is automatically removed.
  *
  * Pending bit list works differently for Thread and Zigbee applications.
- * In case of Thread, pending_bit is set for addresses found on the list.
- * In case of Zigbee, pending_bit is set for short addresses not found on the list.
+ * In case of Thread, pending_bit is set only for the addresses found in the list.
+ * In case of Zigbee, pending_bit is cleared only for the short addresses found in the list.
  * In case of standard-compliant method, pending bit is always true, which requires
  * empty data frame with AR set to 0 to be transmitted immediately afterwards.
  *
- * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
+ * Used method can be set during initialization phase by calling @ref nrf_802154_src_matching_method.
  *
  * @param[in]  p_addr    Array of bytes containing the address of the node (little-endian).
  * @param[in]  extended  If the given address is an extended MAC address or a short MAC address.
@@ -1088,12 +1086,12 @@ void nrf_802154_auto_pending_bit_set(bool enabled);
  * @brief Adds address of a peer node to the pending bit list.
  *
  * Pending bit list works differently for Thread and Zigbee applications.
- * In case of Thread, pending_bit is set for addresses found on the list.
- * In case of Zigbee, pending_bit is set for short addresses not found on the list.
+ * In case of Thread, pending_bit is set only for the addresses found in the list.
+ * In case of Zigbee, pending_bit is cleared only for the short addresses found in the list.
  * In case of standard-compliant method, pending bit is always true, which requires
  * empty data frame with AR set to 0 to be transmitted immediately afterwards.
  *
- * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
+ * Used method can be set during initialization phase by calling @ref nrf_802154_src_matching_method.
  *
  * @note This function makes a copy of the given address.
  *
@@ -1109,12 +1107,12 @@ bool nrf_802154_pending_bit_for_addr_set(const uint8_t * p_addr, bool extended);
  * @brief Removes address of a peer node from the pending bit list.
  *
  * Pending bit list works differently for Thread and Zigbee applications.
- * In case of Thread, pending_bit is set for addresses found on the list.
- * In case of Zigbee, pending_bit is set for short addresses not found on the list.
+ * In case of Thread, pending_bit is set only for the addresses found in the list.
+ * In case of Zigbee, pending_bit is cleared only for the short addresses found in the list.
  * In case of standard-compliant method, pending bit is always true, which requires
  * empty data frame with AR set to 0 to be transmitted immediately afterwards.
  *
- * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
+ * Used method can be set during initialization phase by calling @ref nrf_802154_src_matching_method.
  *
  * @param[in]  p_addr    Array of bytes containing the address of the node (little-endian).
  * @param[in]  extended  If the given address is an extended MAC address or a short MAC address.
@@ -1128,12 +1126,12 @@ bool nrf_802154_pending_bit_for_addr_clear(const uint8_t * p_addr, bool extended
  * @brief Removes all addresses of a given type from the pending bit list.
  *
  * Pending bit list works differently for Thread and Zigbee applications.
- * In case of Thread, pending_bit is set for addresses found on the list.
- * In case of Zigbee, pending_bit is set for short addresses not found on the list.
+ * In case of Thread, pending_bit is set only for the addresses found in the list.
+ * In case of Zigbee, pending_bit is cleared only for the short addresses found in the list.
  * In case of standard-compliant method, pending bit is always true, which requires
  * empty data frame with AR set to 0 to be transmitted immediately afterwards.
  *
- * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
+ * Used method can be set during initialization phase by calling @ref nrf_802154_src_matching_method.
  *
  * @param[in]  extended  If the function is to remove all extended MAC addresses or all short
  *                       addresses.

--- a/src/nrf_802154.h
+++ b/src/nrf_802154.h
@@ -1006,19 +1006,22 @@ bool nrf_802154_pan_coord_get(void);
  *
  * @note This method should be called after driver initialization, but before transceiver is enabled.
  *
- * When calling nrf_802154_ack_data_pending_bit_should_be_set_thread method, several different
- * algorithms can be chosen to determine whether the pending bit in ack should be set.
+ * When calling @ref nrf_802154_ack_data_pending_bit_should_be_set method, it will choose one of
+ * several source address matching algorithms. In order for specific algorithm to be chosen, this
+ * function should be called beforehand.
  *
- * @param[in]  match_method Source matching method to be used.
+ * @param[in]  match_method Source address matching method to be used.
  */
-void nrf_802154_src_matching_method(nrf_802154_src_match_t match_method);
+void nrf_802154_src_addr_matching_method_set(nrf_802154_src_addr_match_t match_method);
 
 /**
- * @brief Adds the address of a peer node for which the provided ACK data is to be added to the pending bit list.
+ * @brief Adds the address of a peer node for which the provided ACK data
+ * is to be added to the pending bit list.
  *
- * Pending bit list works differently for Thread and Zigbee applications.
- * In case of Thread, pending_bit is set only for the addresses found in the list.
- * In case of Zigbee, pending_bit is cleared only for the short addresses found in the list.
+ * Pending bit list works differently, depending on upper layer for which the source
+ * address matching method is selected.
+ * In case of Thread, pending bit is set only for the addresses found in the list.
+ * In case of Zigbee, pending bit is cleared only for the short addresses found in the list.
  * In case of standard-compliant method, pending bit is always true, which requires
  * empty data frame with AR set to 0 to be transmitted immediately afterwards.
  *
@@ -1044,9 +1047,10 @@ bool nrf_802154_ack_data_set(const uint8_t * p_addr,
  *
  * The ACK data that was previously set for the given address is automatically removed.
  *
- * Pending bit list works differently for Thread and Zigbee applications.
- * In case of Thread, pending_bit is set only for the addresses found in the list.
- * In case of Zigbee, pending_bit is cleared only for the short addresses found in the list.
+ * Pending bit list works differently, depending on upper layer for which the source
+ * address matching method is selected.
+ * In case of Thread, pending bit is set only for the addresses found in the list.
+ * In case of Zigbee, pending bit is cleared only for the short addresses found in the list.
  * In case of standard-compliant method, pending bit is always true, which requires
  * empty data frame with AR set to 0 to be transmitted immediately afterwards.
  *
@@ -1085,9 +1089,10 @@ void nrf_802154_auto_pending_bit_set(bool enabled);
 /**
  * @brief Adds address of a peer node to the pending bit list.
  *
- * Pending bit list works differently for Thread and Zigbee applications.
- * In case of Thread, pending_bit is set only for the addresses found in the list.
- * In case of Zigbee, pending_bit is cleared only for the short addresses found in the list.
+ * Pending bit list works differently, depending on upper layer for which the source
+ * address matching method is selected.
+ * In case of Thread, pending bit is set only for the addresses found in the list.
+ * In case of Zigbee, pending bit is cleared only for the short addresses found in the list.
  * In case of standard-compliant method, pending bit is always true, which requires
  * empty data frame with AR set to 0 to be transmitted immediately afterwards.
  *
@@ -1106,9 +1111,10 @@ bool nrf_802154_pending_bit_for_addr_set(const uint8_t * p_addr, bool extended);
 /**
  * @brief Removes address of a peer node from the pending bit list.
  *
- * Pending bit list works differently for Thread and Zigbee applications.
- * In case of Thread, pending_bit is set only for the addresses found in the list.
- * In case of Zigbee, pending_bit is cleared only for the short addresses found in the list.
+ * Pending bit list works differently, depending on upper layer for which the source
+ * address matching method is selected.
+ * In case of Thread, pending bit is set only for the addresses found in the list.
+ * In case of Zigbee, pending bit is cleared only for the short addresses found in the list.
  * In case of standard-compliant method, pending bit is always true, which requires
  * empty data frame with AR set to 0 to be transmitted immediately afterwards.
  *
@@ -1125,9 +1131,10 @@ bool nrf_802154_pending_bit_for_addr_clear(const uint8_t * p_addr, bool extended
 /**
  * @brief Removes all addresses of a given type from the pending bit list.
  *
- * Pending bit list works differently for Thread and Zigbee applications.
- * In case of Thread, pending_bit is set only for the addresses found in the list.
- * In case of Zigbee, pending_bit is cleared only for the short addresses found in the list.
+ * Pending bit list works differently, depending on upper layer for which the source
+ * address matching method is selected.
+ * In case of Thread, pending bit is set only for the addresses found in the list.
+ * In case of Zigbee, pending bit is cleared only for the short addresses found in the list.
  * In case of standard-compliant method, pending bit is always true, which requires
  * empty data frame with AR set to 0 to be transmitted immediately afterwards.
  *

--- a/src/nrf_802154.h
+++ b/src/nrf_802154.h
@@ -1002,7 +1002,12 @@ void nrf_802154_pan_coord_set(bool enabled);
 bool nrf_802154_pan_coord_get(void);
 
 /**
- * @brief Adds the address of a peer node for which the provided ACK data is to be set.
+ * @brief Adds the address of a peer node for which the provided ACK data is to be set to the pending bit list.
+ * 
+ * Pending bit list works differently for Thread and Zigbee applications.
+ * In case of Thread, pending_bit is set for addresses found on the list.
+ * In case of Zigbee, pending_bit is set for short addresses not found on the list.
+ * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
  *
  * @param[in]  p_addr    Array of bytes containing the address of the node (little-endian).
  * @param[in]  extended  If the given address is an extended MAC address or a short MAC address.
@@ -1020,9 +1025,14 @@ bool nrf_802154_ack_data_set(const uint8_t * p_addr,
                              uint8_t         data_type);
 
 /**
- * @brief Removes the address of a peer node for which the ACK data is set.
+ * @brief Removes the address of a peer node for which the ACK data is set from the pending bit list.
  *
  * The ACK data that was previously set for the given address is automatically removed.
+ * 
+ * Pending bit list works differently for Thread and Zigbee applications.
+ * In case of Thread, pending_bit is set for addresses found on the list.
+ * In case of Zigbee, pending_bit is set for short addresses not found on the list.
+ * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
  *
  * @param[in]  p_addr    Array of bytes containing the address of the node (little-endian).
  * @param[in]  extended  If the given address is an extended MAC address or a short MAC address.
@@ -1055,8 +1065,13 @@ bool nrf_802154_ack_data_clear(const uint8_t * p_addr, bool extended, uint8_t da
 void nrf_802154_auto_pending_bit_set(bool enabled);
 
 /**
- * @brief Adds address of a peer node for which there is pending data in the buffer.
- *
+ * @brief Adds address of a peer node to the pending bit list. 
+ * 
+ * Pending bit list works differently for Thread and Zigbee applications.
+ * In case of Thread, pending_bit is set for addresses found on the list.
+ * In case of Zigbee, pending_bit is set for short addresses not found on the list.
+ * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
+ * 
  * @note This function makes a copy of the given address.
  *
  * @param[in]  p_addr    Array of bytes containing the address of the node (little-endian).
@@ -1068,7 +1083,12 @@ void nrf_802154_auto_pending_bit_set(bool enabled);
 bool nrf_802154_pending_bit_for_addr_set(const uint8_t * p_addr, bool extended);
 
 /**
- * @brief Removes address of a peer node for which there is no more pending data in the buffer.
+ * @brief Removes address of a peer node from the pending bit list.
+ * 
+ * Pending bit list works differently for Thread and Zigbee applications.
+ * In case of Thread, pending_bit is set for addresses found on the list.
+ * In case of Zigbee, pending_bit is set for short addresses not found on the list.
+ * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
  *
  * @param[in]  p_addr    Array of bytes containing the address of the node (little-endian).
  * @param[in]  extended  If the given address is an extended MAC address or a short MAC address.
@@ -1080,6 +1100,11 @@ bool nrf_802154_pending_bit_for_addr_clear(const uint8_t * p_addr, bool extended
 
 /**
  * @brief Removes all addresses of a given type from the pending bit list.
+ * 
+ * Pending bit list works differently for Thread and Zigbee applications.
+ * In case of Thread, pending_bit is set for addresses found on the list.
+ * In case of Zigbee, pending_bit is set for short addresses not found on the list.
+ * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
  *
  * @param[in]  extended  If the function is to remove all extended MAC addresses or all short
  *                       addresses.

--- a/src/nrf_802154.h
+++ b/src/nrf_802154.h
@@ -1001,29 +1001,29 @@ void nrf_802154_pan_coord_set(bool enabled);
  */
 bool nrf_802154_pan_coord_get(void);
 
-/** 
+/**
  * @brief Select the source matching algorithm.
- * 
+ *
  * @note This method should only be called in the initialization phase.
- * 
+ *
  * When calling nrf_802154_ack_data_pending_bit_should_be_set_thread method, several different
  * algorithms can be chosen to determine whether the pending bit should be set.
- * 
+ *
  * @see nrf_802154_src_match_t
- * 
+ *
  * @param[in]  match_method Source matching method to be used.
  */
 void nrf_802154_src_matching_method(nrf_802154_src_match_t match_method);
 
 /**
  * @brief Adds the address of a peer node for which the provided ACK data is to be set to the pending bit list.
- * 
+ *
  * Pending bit list works differently for Thread and Zigbee applications.
  * In case of Thread, pending_bit is set for addresses found on the list.
  * In case of Zigbee, pending_bit is set for short addresses not found on the list.
  * In case of standard-compliant method, pending bit is always true, which requires
  * empty data frame with AR set to 0 to be transmitted immediately afterwards.
- * 
+ *
  * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
  *
  * @param[in]  p_addr    Array of bytes containing the address of the node (little-endian).
@@ -1045,13 +1045,13 @@ bool nrf_802154_ack_data_set(const uint8_t * p_addr,
  * @brief Removes the address of a peer node for which the ACK data is set from the pending bit list.
  *
  * The ACK data that was previously set for the given address is automatically removed.
- * 
+ *
  * Pending bit list works differently for Thread and Zigbee applications.
  * In case of Thread, pending_bit is set for addresses found on the list.
  * In case of Zigbee, pending_bit is set for short addresses not found on the list.
  * In case of standard-compliant method, pending bit is always true, which requires
  * empty data frame with AR set to 0 to be transmitted immediately afterwards.
- * 
+ *
  * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
  *
  * @param[in]  p_addr    Array of bytes containing the address of the node (little-endian).
@@ -1085,16 +1085,16 @@ bool nrf_802154_ack_data_clear(const uint8_t * p_addr, bool extended, uint8_t da
 void nrf_802154_auto_pending_bit_set(bool enabled);
 
 /**
- * @brief Adds address of a peer node to the pending bit list. 
- * 
+ * @brief Adds address of a peer node to the pending bit list.
+ *
  * Pending bit list works differently for Thread and Zigbee applications.
  * In case of Thread, pending_bit is set for addresses found on the list.
  * In case of Zigbee, pending_bit is set for short addresses not found on the list.
  * In case of standard-compliant method, pending bit is always true, which requires
  * empty data frame with AR set to 0 to be transmitted immediately afterwards.
- * 
+ *
  * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
- * 
+ *
  * @note This function makes a copy of the given address.
  *
  * @param[in]  p_addr    Array of bytes containing the address of the node (little-endian).
@@ -1107,13 +1107,13 @@ bool nrf_802154_pending_bit_for_addr_set(const uint8_t * p_addr, bool extended);
 
 /**
  * @brief Removes address of a peer node from the pending bit list.
- * 
+ *
  * Pending bit list works differently for Thread and Zigbee applications.
  * In case of Thread, pending_bit is set for addresses found on the list.
  * In case of Zigbee, pending_bit is set for short addresses not found on the list.
  * In case of standard-compliant method, pending bit is always true, which requires
  * empty data frame with AR set to 0 to be transmitted immediately afterwards.
- * 
+ *
  * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
  *
  * @param[in]  p_addr    Array of bytes containing the address of the node (little-endian).
@@ -1126,13 +1126,13 @@ bool nrf_802154_pending_bit_for_addr_clear(const uint8_t * p_addr, bool extended
 
 /**
  * @brief Removes all addresses of a given type from the pending bit list.
- * 
+ *
  * Pending bit list works differently for Thread and Zigbee applications.
  * In case of Thread, pending_bit is set for addresses found on the list.
  * In case of Zigbee, pending_bit is set for short addresses not found on the list.
  * In case of standard-compliant method, pending bit is always true, which requires
  * empty data frame with AR set to 0 to be transmitted immediately afterwards.
- * 
+ *
  * Used method can be set during initialization phase by calling nrf_802154_src_matching_method.
  *
  * @param[in]  extended  If the function is to remove all extended MAC addresses or all short

--- a/src/nrf_802154_const.h
+++ b/src/nrf_802154_const.h
@@ -88,6 +88,16 @@
 #define KEY_ID_MODE_2                0x10                                         ///< Bits containing the 0x10 Key Identifier Mode.
 #define KEY_ID_MODE_3                0x18                                         ///< Bits containing the 0x11 Key Identifier Mode.
 
+#define MAC_CMD_ASSOC_REQ            0x01                                         ///< MAC Association request command frame identifier.
+#define MAC_CMD_ASSOC_RESP           0x02                                         ///< MAC Association response command frame identifier.
+#define MAC_CMD_DISASSOC_NOTIFY      0x03                                         ///< MAC Disaccociation notification command frame identifier.
+#define MAC_CMD_DATA_REQ             0x04                                         ///< MAC Data Requests command frame identifier.
+#define MAC_CMD_PANID_CONFLICT       0x05                                         ///< MAC PAN ID conflict notification command frame identifier.
+#define MAC_CMD_ORPHAN_NOTIFY        0x06                                         ///< MAC Orphan notification command frame identifier.
+#define MAC_CMD_BEACON_REQ           0x07                                         ///< MAC Beacon requestcommand frame identifier.
+#define MAC_CMD_COORD_REALIGN        0x08                                         ///< MAC Coordinator realignment command frame identifier.
+#define MAC_CMD_GTS_REQUEST          0x09                                         ///< MAC GTS request command frame identifier.
+
 #define PAN_ID_COMPR_OFFSET          1                                            ///< Byte containing the PAN ID compression bit (+1 for the frame length byte).
 #define PAN_ID_COMPR_MASK            0x40                                         ///< PAN ID compression bit.
 

--- a/src/nrf_802154_types.h
+++ b/src/nrf_802154_types.h
@@ -141,11 +141,11 @@ typedef uint8_t nrf_802154_ack_data_t;
 /**
  * @brief Methods of source address matching.
  */
-typedef uint8_t nrf_802154_src_match_t;
+typedef uint8_t nrf_802154_src_addr_match_t;
 
-#define NRF_802154_SRC_MATCH_THREAD   0x00 // !< Implementation for Thread protocol.
-#define NRF_802154_SRC_MATCH_ZIGBEE   0x01 // !< Implementation for ZigBee protocol.
-#define NRF_802154_SRC_MATCH_ALWAYS_1 0x02 // !< Standard-compliant implementation - PB is always set to 1.
+#define NRF_802154_SRC_ADDR_MATCH_THREAD   0x00 // !< Implementation for Thread protocol.
+#define NRF_802154_SRC_ADDR_MATCH_ZIGBEE   0x01 // !< Implementation for ZigBee protocol.
+#define NRF_802154_SRC_ADDR_MATCH_ALWAYS_1 0x02 // !< Standard-compliant implementation - Pending bit is always set to 1.
 
 /**
  * @brief RSSI measurement results.

--- a/src/nrf_802154_types.h
+++ b/src/nrf_802154_types.h
@@ -143,8 +143,9 @@ typedef uint8_t nrf_802154_ack_data_t;
  */
 typedef uint8_t nrf_802154_src_match_t;
 
-#define NRF_802154_SRC_MATCH_THREAD 0x00
-#define NRF_802154_SRC_MATCH_ZIGBEE 0x01
+#define NRF_802154_SRC_MATCH_THREAD   0x00  // !< Implementation for Thread protocol.
+#define NRF_802154_SRC_MATCH_ZIGBEE   0x01  // !< Implementation for ZigBee protocol.
+#define NRF_802154_SRC_MATCH_STANDARD 0x02  // !< Standard-compliant implementation - PB is always set to 1.
 
 /**
  * @brief RSSI measurement results.

--- a/src/nrf_802154_types.h
+++ b/src/nrf_802154_types.h
@@ -139,6 +139,14 @@ typedef uint8_t nrf_802154_ack_data_t;
 #define NRF_802154_ACK_DATA_IE          0x01
 
 /**
+ * @brief Methods of source address matching.
+ */
+typedef uint8_t nrf_802154_src_match_t;
+
+#define NRF_802154_SRC_MATCH_THREAD 0x00
+#define NRF_802154_SRC_MATCH_ZIGBEE 0x01
+
+/**
  * @brief RSSI measurement results.
  */
 

--- a/src/nrf_802154_types.h
+++ b/src/nrf_802154_types.h
@@ -143,9 +143,9 @@ typedef uint8_t nrf_802154_ack_data_t;
  */
 typedef uint8_t nrf_802154_src_match_t;
 
-#define NRF_802154_SRC_MATCH_THREAD   0x00  // !< Implementation for Thread protocol.
-#define NRF_802154_SRC_MATCH_ZIGBEE   0x01  // !< Implementation for ZigBee protocol.
-#define NRF_802154_SRC_MATCH_STANDARD 0x02  // !< Standard-compliant implementation - PB is always set to 1.
+#define NRF_802154_SRC_MATCH_THREAD   0x00 // !< Implementation for Thread protocol.
+#define NRF_802154_SRC_MATCH_ZIGBEE   0x01 // !< Implementation for ZigBee protocol.
+#define NRF_802154_SRC_MATCH_STANDARD 0x02 // !< Standard-compliant implementation - PB is always set to 1.
 
 /**
  * @brief RSSI measurement results.

--- a/src/nrf_802154_types.h
+++ b/src/nrf_802154_types.h
@@ -145,7 +145,7 @@ typedef uint8_t nrf_802154_src_match_t;
 
 #define NRF_802154_SRC_MATCH_THREAD   0x00 // !< Implementation for Thread protocol.
 #define NRF_802154_SRC_MATCH_ZIGBEE   0x01 // !< Implementation for ZigBee protocol.
-#define NRF_802154_SRC_MATCH_STANDARD 0x02 // !< Standard-compliant implementation - PB is always set to 1.
+#define NRF_802154_SRC_MATCH_ALWAYS_1 0x02 // !< Standard-compliant implementation - PB is always set to 1.
 
 /**
  * @brief RSSI measurement results.

--- a/test/unit tests/ack_source_matching/config.yml
+++ b/test/unit tests/ack_source_matching/config.yml
@@ -1,0 +1,3 @@
+---
+:cmock:
+  :fail_on_unexpected_calls: true

--- a/test/unit tests/ack_source_matching/test_nrf_driver_ack_source_matching.json
+++ b/test/unit tests/ack_source_matching/test_nrf_driver_ack_source_matching.json
@@ -1,0 +1,23 @@
+{
+    "_attrs": [
+        "test"
+      ],
+    "_links": [
+        "appskeleton_unity_nrf52",
+        "nrf_802154:cmock_for_ack_data",
+        "raal:cmock",
+        "fem:cmock",
+        "hal_nrf_egu:cmock",
+        "hal_nrf_ppi:cmock",
+        "hal_nrf_radio:cmock",
+        "hal_nrf_rtc:cmock",
+        "hal_nrf_timer:cmock"
+    ],
+    "_defines": [
+        "NRF52840_XXAA"
+    ],
+    "_toolchains": [
+        "gcc"
+    ],
+    "_name": "test_nrf_driver_ack_source_matching"
+}

--- a/test/unit tests/ack_source_matching/unity_test.c
+++ b/test/unit tests/ack_source_matching/unity_test.c
@@ -61,14 +61,14 @@ static uint8_t test_addr_short_1[SHORT_ADDRESS_SIZE]       = { 0x12, 0x23 };
 static nrf_802154_frame_parser_mhr_data_t test_mhr_data_short    = 
 {
     .p_src_addr = &(test_psdu_short[8]),
-    .src_addr_size = SRC_ADDR_TYPE_SHORT,
+    .src_addr_size = SHORT_ADDRESS_SIZE,
     .addressing_end_offset = 10
 };
 
 static nrf_802154_frame_parser_mhr_data_t test_mhr_data_extended = 
 {
     .p_src_addr = test_addr_extended_1,
-    .src_addr_size = SRC_ADDR_TYPE_EXTENDED,
+    .src_addr_size = EXTENDED_ADDRESS_SIZE,
     .addressing_end_offset = 22
 };
 

--- a/test/unit tests/ack_source_matching/unity_test.c
+++ b/test/unit tests/ack_source_matching/unity_test.c
@@ -1,0 +1,334 @@
+/* Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *      list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ *
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include "unity.h"
+
+#include "nrf_802154_const.h"
+#include "mock_nrf_802154.h"
+#include "mock_nrf_802154_frame_parser.h"
+
+#include "mac_features/ack_generator/nrf_802154_ack_data.c"
+
+#define FCF_BYTE_0_DATA 0x41
+#define FCF_BYTE_0_CMD  0x43
+
+/***********************************************************************************/
+/********************** ACK PENDING BIT SOURCE MATCHING TESTS **********************/
+/***********************************************************************************/
+static uint8_t test_psdu_extended[EXTENDED_ADDRESS_SIZE + SRC_ADDR_OFFSET_EXTENDED_DST + 1] = 
+{
+    0x00, FCF_BYTE_0_CMD, 0xcc, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
+    0x00, 0x00, 0x00, 0x00, 0x12, 0x23, 0x34, 0x45, 0x56, 0x67, 0x78, 0x89,
+    MAC_CMD_DATA_REQ
+};
+
+static uint8_t test_psdu_short[SHORT_ADDRESS_SIZE + SRC_ADDR_OFFSET_SHORT_DST + 1] = 
+{
+    0x00, FCF_BYTE_0_CMD, 0xaa, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x23, 
+    MAC_CMD_DATA_REQ 
+};
+
+static uint8_t test_addr_extended_1[EXTENDED_ADDRESS_SIZE] = { 0x12, 0x23, 0x34, 0x45, 0x56, 0x67, 0x78, 0x89 };
+static uint8_t test_addr_short_1[SHORT_ADDRESS_SIZE]       = { 0x12, 0x23 };
+
+static nrf_802154_frame_parser_mhr_data_t test_mhr_data_short    = 
+{
+    .p_src_addr = &(test_psdu_short[8]),
+    .src_addr_size = SRC_ADDR_TYPE_SHORT,
+    .addressing_end_offset = 10
+};
+
+static nrf_802154_frame_parser_mhr_data_t test_mhr_data_extended = 
+{
+    .p_src_addr = test_addr_extended_1,
+    .src_addr_size = SRC_ADDR_TYPE_EXTENDED,
+    .addressing_end_offset = 22
+};
+
+static bool test_extended_flag = false;
+/***********************************************************************************/
+/***********************************************************************************/
+/***********************************************************************************/
+
+// Default state before test case - correct payload, address not on list, checking enabled.
+void setUp(void)
+{    
+    nrf_802154_ack_data_enable(true);
+    
+}
+
+void tearDown(void)
+{
+    memset(m_pending_bit.extended_addr, 0, sizeof(m_pending_bit.extended_addr));
+    memset(m_pending_bit.short_addr, 0xff, sizeof(m_pending_bit.short_addr));
+
+    test_psdu_extended[test_mhr_data_extended.addressing_end_offset] = MAC_CMD_DATA_REQ;
+    test_psdu_short[test_mhr_data_short.addressing_end_offset]       = MAC_CMD_DATA_REQ;
+    test_psdu_extended[FRAME_TYPE_OFFSET]                            = FCF_BYTE_0_CMD;
+    test_psdu_short[FRAME_TYPE_OFFSET]                               = FCF_BYTE_0_CMD;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+/***********************************************************************************/
+
+// Standard compliant - always returns true.
+void test_StandardCompliantAlwaysTrue()
+{   
+    bool res;
+    nrf_802154_ack_data_src_addr_matching_method_set(NRF_802154_SRC_ADDR_MATCH_ALWAYS_1);
+
+    res = nrf_802154_ack_data_pending_bit_should_be_set(test_psdu_short);
+    TEST_ASSERT_TRUE(res);
+}
+
+// Thread - if module disabled, always returns true.
+void test_ThreadPendingDisabled()
+{
+    bool res;
+    nrf_802154_ack_data_src_addr_matching_method_set(NRF_802154_SRC_ADDR_MATCH_THREAD);
+    nrf_802154_ack_data_enable(false);
+    test_extended_flag = false;
+
+    nrf_802154_frame_parser_src_addr_get_ExpectAndReturn(test_psdu_short, &test_extended_flag, test_addr_short_1);
+    nrf_802154_frame_parser_src_addr_get_IgnoreArg_p_src_addr_extended();
+    nrf_802154_frame_parser_src_addr_get_ReturnThruPtr_p_src_addr_extended(&test_extended_flag);
+
+    res = nrf_802154_ack_data_pending_bit_should_be_set(test_psdu_short);
+    TEST_ASSERT_TRUE(res);
+}
+
+// Thread - if no source address found, always returns true.
+void test_ThreadSourceAddressNULL()
+{
+    bool res;
+    nrf_802154_ack_data_src_addr_matching_method_set(NRF_802154_SRC_ADDR_MATCH_THREAD);
+    test_extended_flag = false;
+
+    nrf_802154_frame_parser_src_addr_get_ExpectAndReturn(test_psdu_short, &test_extended_flag, NULL);
+    nrf_802154_frame_parser_src_addr_get_IgnoreArg_p_src_addr_extended();
+    nrf_802154_frame_parser_src_addr_get_ReturnThruPtr_p_src_addr_extended(&test_extended_flag);
+
+    res = nrf_802154_ack_data_pending_bit_should_be_set(test_psdu_short);
+    TEST_ASSERT_TRUE(res);
+}
+
+// Thread - if short address found on list, return true.
+void test_ThreadShortAddressOnList()
+{
+    bool res;
+    nrf_802154_ack_data_src_addr_matching_method_set(NRF_802154_SRC_ADDR_MATCH_THREAD);
+    test_extended_flag = false;
+
+    res = nrf_802154_ack_data_for_addr_set(test_addr_short_1, test_extended_flag, NRF_802154_ACK_DATA_PENDING_BIT, NULL, 0);
+    TEST_ASSERT_TRUE(res);
+
+    nrf_802154_frame_parser_src_addr_get_ExpectAndReturn(test_psdu_short, &test_extended_flag, test_addr_short_1);
+    nrf_802154_frame_parser_src_addr_get_IgnoreArg_p_src_addr_extended();
+    nrf_802154_frame_parser_src_addr_get_ReturnThruPtr_p_src_addr_extended(&test_extended_flag);
+
+    res = nrf_802154_ack_data_pending_bit_should_be_set(test_psdu_short);
+    TEST_ASSERT_TRUE(res);
+}
+
+// Thread - if extended address found on list, return true.
+void test_ThreadExtAddressOnList()
+{
+    bool res;
+    nrf_802154_ack_data_src_addr_matching_method_set(NRF_802154_SRC_ADDR_MATCH_THREAD);
+    test_extended_flag = true;
+
+    res = nrf_802154_ack_data_for_addr_set(test_addr_extended_1, test_extended_flag, NRF_802154_ACK_DATA_PENDING_BIT, NULL, 0);
+    TEST_ASSERT_TRUE(res);
+
+    nrf_802154_frame_parser_src_addr_get_ExpectAndReturn(test_psdu_extended, &test_extended_flag, test_addr_extended_1);
+    nrf_802154_frame_parser_src_addr_get_IgnoreArg_p_src_addr_extended();
+    nrf_802154_frame_parser_src_addr_get_ReturnThruPtr_p_src_addr_extended(&test_extended_flag);
+
+    res = nrf_802154_ack_data_pending_bit_should_be_set(test_psdu_extended);
+    TEST_ASSERT_TRUE(res);
+}
+
+// Thread - if short address not found on list, return false.
+void test_ThreadShortAddressNotOnList()
+{
+    bool res;
+    nrf_802154_ack_data_src_addr_matching_method_set(NRF_802154_SRC_ADDR_MATCH_THREAD);
+    test_extended_flag = false;
+
+    nrf_802154_frame_parser_src_addr_get_ExpectAndReturn(test_psdu_short, &test_extended_flag, test_addr_short_1);
+    nrf_802154_frame_parser_src_addr_get_IgnoreArg_p_src_addr_extended();
+    nrf_802154_frame_parser_src_addr_get_ReturnThruPtr_p_src_addr_extended(&test_extended_flag);
+
+    res = nrf_802154_ack_data_pending_bit_should_be_set(test_psdu_short);
+    TEST_ASSERT_FALSE(res);
+}
+
+// Thread - if extended address not found on list, return false.
+void test_ThreadExtAddressNotOnList()
+{
+    bool res;
+    nrf_802154_ack_data_src_addr_matching_method_set(NRF_802154_SRC_ADDR_MATCH_THREAD);
+    test_extended_flag = true;
+
+    nrf_802154_frame_parser_src_addr_get_ExpectAndReturn(test_psdu_extended, &test_extended_flag, test_addr_extended_1);
+    nrf_802154_frame_parser_src_addr_get_IgnoreArg_p_src_addr_extended();
+    nrf_802154_frame_parser_src_addr_get_ReturnThruPtr_p_src_addr_extended(&test_extended_flag);
+
+    res = nrf_802154_ack_data_pending_bit_should_be_set(test_psdu_extended);
+    TEST_ASSERT_FALSE(res);
+}
+
+// ZigBee - if module disabled - return true.
+void test_ZigBeePendingDisabled()
+{
+    bool res;
+    nrf_802154_ack_data_src_addr_matching_method_set(NRF_802154_SRC_ADDR_MATCH_ZIGBEE);
+    nrf_802154_ack_data_enable(false);
+
+    res = nrf_802154_ack_data_pending_bit_should_be_set(test_psdu_short);
+    TEST_ASSERT_TRUE(res);
+}
+
+// ZigBee - if mhr parsing returns false, return true.
+void test_ZigBeeParseFailed()
+{
+    bool res;
+    nrf_802154_ack_data_src_addr_matching_method_set(NRF_802154_SRC_ADDR_MATCH_ZIGBEE);
+
+    nrf_802154_frame_parser_mhr_parse_ExpectAndReturn(test_psdu_short, &test_mhr_data_short, false);
+    nrf_802154_frame_parser_mhr_parse_IgnoreArg_p_fields();
+    nrf_802154_frame_parser_mhr_parse_ReturnThruPtr_p_fields(&test_mhr_data_short);
+
+    res = nrf_802154_ack_data_pending_bit_should_be_set(test_psdu_short);
+    TEST_ASSERT_TRUE(res);
+}
+
+// ZigBee - if frame is not MAC command frame, return false.
+void test_ZigBeeTypeNotCommand()
+{
+    bool res;
+    nrf_802154_ack_data_src_addr_matching_method_set(NRF_802154_SRC_ADDR_MATCH_ZIGBEE);
+    test_psdu_short[FRAME_TYPE_OFFSET] = FCF_BYTE_0_DATA;
+
+    nrf_802154_frame_parser_mhr_parse_ExpectAndReturn(test_psdu_short, &test_mhr_data_short, true);
+    nrf_802154_frame_parser_mhr_parse_IgnoreArg_p_fields();
+    nrf_802154_frame_parser_mhr_parse_ReturnThruPtr_p_fields(&test_mhr_data_short);
+
+    res = nrf_802154_ack_data_pending_bit_should_be_set(test_psdu_short);
+    TEST_ASSERT_FALSE(res);
+}
+
+// ZigBee - if command is not data request, return false.
+// Checked for both short and extended, as offsets differ.
+void test_ZigBeeCommandNotRequest()
+{
+    bool res;
+    nrf_802154_ack_data_src_addr_matching_method_set(NRF_802154_SRC_ADDR_MATCH_ZIGBEE);
+
+    // Short
+    test_psdu_short[test_mhr_data_short.addressing_end_offset] = MAC_CMD_BEACON_REQ;
+
+    nrf_802154_frame_parser_mhr_parse_ExpectAndReturn(test_psdu_short, &test_mhr_data_short, true);
+    nrf_802154_frame_parser_mhr_parse_IgnoreArg_p_fields();
+    nrf_802154_frame_parser_mhr_parse_ReturnThruPtr_p_fields(&test_mhr_data_short);
+
+    res = nrf_802154_ack_data_pending_bit_should_be_set(test_psdu_short);
+    TEST_ASSERT_FALSE(res);
+    
+    // Extended
+    test_psdu_extended[test_mhr_data_extended.addressing_end_offset] = MAC_CMD_BEACON_REQ;
+
+    nrf_802154_frame_parser_mhr_parse_ExpectAndReturn(test_psdu_extended, &test_mhr_data_extended, true);
+    nrf_802154_frame_parser_mhr_parse_IgnoreArg_p_fields();
+    nrf_802154_frame_parser_mhr_parse_ReturnThruPtr_p_fields(&test_mhr_data_extended);
+
+    res = nrf_802154_ack_data_pending_bit_should_be_set(test_psdu_extended);
+    TEST_ASSERT_FALSE(res);
+}
+
+// ZigBee - if frame is on the list, return false if address is short address, true otherwise.
+void test_ZigBeeAddressOnList()
+{
+    bool res;
+    nrf_802154_ack_data_src_addr_matching_method_set(NRF_802154_SRC_ADDR_MATCH_ZIGBEE);
+
+    // Short
+    test_extended_flag = false;
+    res = nrf_802154_ack_data_for_addr_set(test_addr_short_1, test_extended_flag, NRF_802154_ACK_DATA_PENDING_BIT, NULL, 0);
+    TEST_ASSERT_TRUE(res);
+
+    nrf_802154_frame_parser_mhr_parse_ExpectAndReturn(test_psdu_short, &test_mhr_data_short, true);
+    nrf_802154_frame_parser_mhr_parse_IgnoreArg_p_fields();
+    nrf_802154_frame_parser_mhr_parse_ReturnThruPtr_p_fields(&test_mhr_data_short);
+
+    res = nrf_802154_ack_data_pending_bit_should_be_set(test_psdu_short);
+    TEST_ASSERT_FALSE(res);
+
+    // Extended
+    test_extended_flag = true;
+    res = nrf_802154_ack_data_for_addr_set(test_addr_extended_1, test_extended_flag, NRF_802154_ACK_DATA_PENDING_BIT, NULL, 0);
+    TEST_ASSERT_TRUE(res);
+
+    nrf_802154_frame_parser_mhr_parse_ExpectAndReturn(test_psdu_extended, &test_mhr_data_extended, true);
+    nrf_802154_frame_parser_mhr_parse_IgnoreArg_p_fields();
+    nrf_802154_frame_parser_mhr_parse_ReturnThruPtr_p_fields(&test_mhr_data_extended);
+
+    res = nrf_802154_ack_data_pending_bit_should_be_set(test_psdu_extended);
+    TEST_ASSERT_TRUE(res);
+}
+
+// ZigBee - if frame is not on the list, return true.
+// Checked for both short and extended address, as decision path differs.
+void test_ZigBeeAddressNotOnList()
+{
+    bool res;
+    nrf_802154_ack_data_src_addr_matching_method_set(NRF_802154_SRC_ADDR_MATCH_ZIGBEE);
+
+    // Short
+    test_extended_flag = false;
+
+    nrf_802154_frame_parser_mhr_parse_ExpectAndReturn(test_psdu_short, &test_mhr_data_short, true);
+    nrf_802154_frame_parser_mhr_parse_IgnoreArg_p_fields();
+    nrf_802154_frame_parser_mhr_parse_ReturnThruPtr_p_fields(&test_mhr_data_short);
+
+    res = nrf_802154_ack_data_pending_bit_should_be_set(test_psdu_short);
+    TEST_ASSERT_TRUE(res);
+
+    // Extended
+    test_extended_flag = true;
+
+    nrf_802154_frame_parser_mhr_parse_ExpectAndReturn(test_psdu_extended, &test_mhr_data_extended, true);
+    nrf_802154_frame_parser_mhr_parse_IgnoreArg_p_fields();
+    nrf_802154_frame_parser_mhr_parse_ReturnThruPtr_p_fields(&test_mhr_data_extended);
+
+    res = nrf_802154_ack_data_pending_bit_should_be_set(test_psdu_extended);
+    TEST_ASSERT_TRUE(res);
+}


### PR DESCRIPTION
New feature - choosing between two source matching algorithms when determining whether the pending bit is to be set when transmitting ACK.
Implementation review only. Pull request to nordic repo will be created after unit tests are implemented and ran without failing.